### PR TITLE
Module to switch audio device on connect

### DIFF
--- a/pulse/default.pa.droid
+++ b/pulse/default.pa.droid
@@ -157,3 +157,4 @@ load-module module-filter-apply
 ### Make some devices default
 #set-default-sink sink.primary
 #set-default-source source.primary
+load-module module-switch-on-connect


### PR DESCRIPTION
Added auto switch module, idk why we didnt have this before? anyway, if a bluetooth or wired device is connected it should automatically switch to it. This module needs to be included for that to happen